### PR TITLE
create search component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { RepositoryType } from './types'
 import { SpinnerIcon } from './components/icons'
 import { GET_REACT_REPOSITORIES } from './queries/RepositoriesQuery'
 import Pagination from './components/Pagination'
+import Search from './components/Search'
 import './styles/global.css'
 
 
@@ -44,7 +45,13 @@ function App() {
   const [paginationLabels, setPaginationLabels] = useState([1,2,3,4,5])
 
   const { data, loading, error, refetch } = useQuery<QueryProps>(GET_REACT_REPOSITORIES, {
-    variables: { first: ITEMS_PER_PAGE, last: null, after: null, before: null }
+    variables: { 
+      first: ITEMS_PER_PAGE,
+      last: null,
+      after: null,
+      before: null,
+      querystring: "topic:python sort:updated-asc"
+    }
   })
   
   useEffect(() => {
@@ -74,6 +81,17 @@ function App() {
 
   if (error) {
     return <p>Error {error.message}</p>
+  }
+
+  function handleSearch(term: string) {
+    setPageLoading(true)
+    refetch({
+      querystring: term
+    }).catch(err => {
+      console.log(err)
+    }).finally(() => {
+      setPageLoading(false)
+    })
   }
 
   async function handlePageClick(id: number) {
@@ -120,9 +138,10 @@ function App() {
   }
 
   return (
-    <div className='bg-slate-50 w-full h-full py-8'>
-      <h1 className='text-3xl mb-8'>Popular Repositories</h1>
-      <div className='flex justify-center'>
+    <div className='bg-slate-50 w-full  py-8 flex flex-col justify-center items-center'>
+      <h1 className='w-full text-center text-3xl mb-8 p-0'>Popular Repositories</h1>
+      <div className='flex flex-col items-center justify-center w-full max-w-4xl'>
+        <Search handleSearch={handleSearch} />
         {
           pageLoading ? (
             <div className='flex flex-col justify-center items-center gap-4 mt-8'>

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -1,0 +1,32 @@
+import { ChangeEvent, useState } from "react"
+
+type SearchProps = {
+  handleSearch: (term: string) => void
+}
+const Search = ({ handleSearch }: SearchProps) => {
+  const [searchTerm, setSearchTerm] = useState("")
+
+  function handleOnChange(event: ChangeEvent<HTMLInputElement>) {
+    setSearchTerm(event.target.value)
+  }
+
+  return (
+    <div className="w-full h-20 bg-sky-200 rounded-xl p-4 mb-10 flex justify-center gap-10">
+      <input
+        type="search"
+        value={searchTerm}
+        onChange={handleOnChange}
+        placeholder="Type a search term"
+        className="w-10/12 max-w-[400px] rounded shadow-sm text-zinc-700 text-xl px-4"
+      />
+      <button
+        className="bg-sky-700 text-white w-[80px] rounded shadow-sm text-2xl hover:bg-sky-500"
+        onClick={() => handleSearch(searchTerm)}
+      >
+        Go
+      </button>
+    </div>
+  )
+}
+
+export default Search

--- a/src/components/TableList.tsx
+++ b/src/components/TableList.tsx
@@ -8,7 +8,7 @@ type RepositoriesListType = {
 function TableList({ repositoriesList }: RepositoriesListType) {
 
   return (
-    <div className="shadow overflow-hidden rounded-xl border-b border-gray-200 w-full max-w-4xl">
+    <div className="shadow overflow-hidden rounded-xl border-b border-gray-200 w-full">
       <table className="w-full bg-white">
         <thead className="bg-gray-800 text-white">
           <tr className="text-left h-14 text-xl">

--- a/src/queries/RepositoriesQuery.ts
+++ b/src/queries/RepositoriesQuery.ts
@@ -1,8 +1,15 @@
 import { gql } from '@apollo/client'
 
 export const GET_REACT_REPOSITORIES = gql`
-  query GetRepositories ($first: Int, $last: Int, $after: String, $before: String) {
-    search (query:"topic:react sort:updated-asc", type: REPOSITORY, first: $first, last: $last, after: $after, before: $before) {
+  query GetRepositories ($first: Int, $last: Int, $after: String, $before: String, $querystring: String!) {
+    search (
+      query: $querystring,
+      type: REPOSITORY,
+      first: $first,
+      last: $last,
+      after: $after,
+      before: $before
+    ) {
       pageInfo {
         endCursor
         startCursor


### PR DESCRIPTION
# Add Search Feature

This PR implements a Search Field, which allows us to search for terms on the Githup repositories.

For example: you can search for **pascal**, which will return a list of respositories containing the pascal term and pascal language.

## Videos and Screenshots


https://github.com/darde/github-graphql-pagination/assets/24977035/a87193dd-6c94-4a3e-a35d-ba2b7b489aad

